### PR TITLE
Constexpr for static doubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To get help, read the man page or run
 
 Here are a few examples of YASA's invocation.
 
-    yasa -i o -o o source.ospl target.ospl result.alignment
+    yasa -i o -o r source.ospl target.ospl result.alignment
     
 will align two texts that are tokenized in the one sentence per line format and
 output a result (result.alignment) showing the sentence alignment. The format

--- a/lib/libyasa/churchgalescore.h
+++ b/lib/libyasa/churchgalescore.h
@@ -273,7 +273,7 @@ public :
      * Substitution ( 1-1 ) probability as in [Church & Gale].
      * \endenglish
      */
-    static const double DEFAULT_PROB_11 = 0.89;
+    static constexpr double DEFAULT_PROB_11 = 0.89;
 
     /** 
      * \french
@@ -284,7 +284,7 @@ public :
      * Insertion ( 0-1 ) probability as in [Church & Gale].
      * \endenglish
      */
-    static const double DEFAULT_PROB_01 = 0.0099;
+    static constexpr double DEFAULT_PROB_01 = 0.0099;
 
     /** 
      * \french
@@ -295,7 +295,7 @@ public :
      * Deletion ( 1-0 ) probability as in [Church & Gale].
      * \endenglish
      */
-    static const double DEFAULT_PROB_10 = 0.0099;
+    static constexpr double DEFAULT_PROB_10 = 0.0099;
 
     /** 
      * \french
@@ -306,7 +306,7 @@ public :
      * Expension ( 1-2 ) probability as in [Church & Gale]. 
      * \endenglish
      */
-    static const double DEFAULT_PROB_12 = 0.089;
+    static constexpr double DEFAULT_PROB_12 = 0.089;
 
     /** 
      * \french
@@ -317,7 +317,7 @@ public :
      * Contraction ( 2-1 ) probability as in [Church & Gale].
      * \endenglish
      */
-    static const double DEFAULT_PROB_21 = 0.089;
+    static constexpr double DEFAULT_PROB_21 = 0.089;
 
     /** 
      * \french
@@ -328,7 +328,7 @@ public :
      * Merge ( 2-2 ) probability as in [Church & Gale].
      * \endenglish
      */
-    static const double DEFAULT_PROB_22 = 0.011;
+    static constexpr double DEFAULT_PROB_22 = 0.011;
  
     /** 
      * \french
@@ -340,7 +340,7 @@ public :
      * The average production as in [Church & Gale]. 
      * \endenglish
      */ 
-    static const double DEFAULT_PRODUCTION = 1;
+    static constexpr double DEFAULT_PRODUCTION = 1;
 
     /**
      * \french
@@ -355,7 +355,7 @@ public :
      * variance ).
      * \endenglish
      */
-    static const double DEFAULT_VARIANCE = 6.8;
+    static constexpr double DEFAULT_VARIANCE = 6.8;
     
     /** 
      * \french
@@ -366,7 +366,7 @@ public :
      * Default <em>match</em>'s weight.
      * \endenglish
      */
-    static const double DEFAULT_MATCH_WEIGHT  = 0.2;
+    static constexpr double DEFAULT_MATCH_WEIGHT  = 0.2;
 
     /** 
      * \french
@@ -377,7 +377,7 @@ public :
      * Default <em>penalty</em>'s weight.
      * \endenglish
      */
-    static const double DEFAULT_PENALTY_WEIGHT = 1;
+    static constexpr double DEFAULT_PENALTY_WEIGHT = 1;
 
 protected :    
     /**

--- a/lib/libyasa/felipescore.h
+++ b/lib/libyasa/felipescore.h
@@ -353,7 +353,7 @@ public :
      * The default weight of the Church and Gale's score function.
      * \endenglish
      */ 
-    static const double DEFAULT_CHURCH_GALE_WEIGHT = 1;
+    static constexpr double DEFAULT_CHURCH_GALE_WEIGHT = 1;
 
     /** 
      * \french
@@ -364,7 +364,7 @@ public :
      * The default weight of the Simard's score function.
      * \endenglish
      */
-    static const double DEFAULT_SIMARD_WEIGHT = 0.85;
+    static constexpr double DEFAULT_SIMARD_WEIGHT = 0.85;
 
     /** 
      * \french
@@ -377,7 +377,7 @@ public :
      * are traductions of each other.
      * \endenglish
      */
-    static const double DEFAULT_CPT = 0.3;
+    static constexpr double DEFAULT_CPT = 0.3;
 
     /**
      * \french
@@ -390,7 +390,7 @@ public :
      * are not traductions of each other.
      * \endenglish
      */
-    static const double DEFAULT_CPNT = 0.09;
+    static constexpr double DEFAULT_CPNT = 0.09;
 
     /** 
      * \french
@@ -412,7 +412,7 @@ public :
      * Default FullFelipe correction.
      * \endenglish
      */
-    static const double DEFAULT_CORRECTION = 2;
+    static constexpr double DEFAULT_CORRECTION = 2;
 
 protected :
     

--- a/lib/libyasa/wordscorefunction.h
+++ b/lib/libyasa/wordscorefunction.h
@@ -70,7 +70,7 @@ public :
      * The default cost of a return. 
      * \endenglish
      */
-    static const double DEFAULT_RETURN_COST = 5;
+    static constexpr double DEFAULT_RETURN_COST = 5;
     
     /**
      * \french


### PR DESCRIPTION
Running `g++` 11.4.0 from Ubuntu 22.04 requires non-integral types to be initialised using `constexpr` in the class declaration. See [here](https://stackoverflow.com/questions/9141950/initializing-const-member-within-class-declaration-in-c).